### PR TITLE
Usability, bugfixes and material improvements

### DIFF
--- a/evm/importer/evmImportOperator.py
+++ b/evm/importer/evmImportOperator.py
@@ -1,6 +1,8 @@
 import bpy
 from bpy_extras.io_utils import ImportHelper
 import os
+from ...util.util import replaceExt
+
 
 texture_modes = [
     ('none', 'No Textures', 'Do not load textures'),


### PR DESCRIPTION
**EVM and KMS multi-import**
Now multiple files can be selected and exported in a single operation.

**Material Setup Improvements**
Currently, environment maps were not being used correctly, so my approach is to actually sample them using a **Reflection** vector multiplying it with the **Specular Map** and sending them to the **Emission Color** input of the BSDF.

Additionally, when a material's base color map is implied to be opaque, the alpha channel will be disconnected, this way, Blender will treat them as truly opaque. As seen in the names of the CTXR files, textures often carry keywords in their names that imply the blending mode that they are paired with (alp, ovl, mod, sub, add). Using this information it is now possible to only attach the Alpha channel when required, allowing Blender to treat opaque materials as truly opaque, this is most noticeable when a material is set to "Alpha Blend" rather than "Alpha Hash" but it helps regardless.

Texture blending mode guesswork now relies on the CTXR name dictionary. This allows Alpha Blended texture detection even when importing models with their TRI textures.

**Unrelated bugfix**
Fixed crash when attempting EVM import with TRI textures.