### PR TITLE
'Merge Material Slots' import setting

### DIFF
--- a/evm/importer/evmImportOperator.py
+++ b/evm/importer/evmImportOperator.py
@@ -30,6 +30,7 @@ class ImportMgsEvm(bpy.types.Operator, ImportHelper):
     texture_mode: bpy.props.EnumProperty(name="Textures", items=texture_modes, default=0, update=changeTextureMode)
     texture_path: bpy.props.StringProperty(name="Load Path:")
     texture_overwrite: bpy.props.BoolProperty(name="Re-extract existing", default=False)
+    merge_material_slots: bpy.props.BoolProperty(name="Merge Similar Material Slots", default=True)
 
     files: bpy.props.CollectionProperty(
         name="EVM files",
@@ -71,11 +72,11 @@ class ImportMgsEvm(bpy.types.Operator, ImportHelper):
             if self.texture_mode == 'ctxr':
                 # Unless you want to unpack every ctxr in advance, this has to be in the kms loader.
                 if os.path.isabs(self.texture_path):
-                    evm_importer.main(evm_path, self.texture_path, self.texture_overwrite)
+                    evm_importer.main(evm_path, self.texture_path, self.texture_overwrite, self.merge_material_slots)
                 else:
-                    evm_importer.main(evm_path, os.path.join(dirname, self.texture_path), self.texture_overwrite)
+                    evm_importer.main(evm_path, os.path.join(dirname, self.texture_path), self.texture_overwrite, self.merge_material_slots)
             else:
-                evm_importer.main(evm_path)
+                evm_importer.main(evm_path, merge_material_slots = self.merge_material_slots)
             
         return {'FINISHED'}
         
@@ -88,3 +89,5 @@ class ImportMgsEvm(bpy.types.Operator, ImportHelper):
             col.prop(self, "texture_path")
         if self.texture_mode == 'ctxr':
             col.prop(self, "texture_overwrite")
+        col.prop(self, "merge_material_slots")
+

--- a/evm/importer/evm_importer.py
+++ b/evm/importer/evm_importer.py
@@ -5,7 +5,7 @@ from mathutils import Vector
 from math import radians
 from ...kms.importer.rotationWrapperObj import objRotationWrapper
 from ...util.util import getBoneName, expected_parent_bones
-from ...util.materials import TextureLoad
+from ...util.materials import TextureLoad, MaterialHelper
 import bmesh
 
 DEFAULT_BONE_LENGTH = 10
@@ -41,7 +41,7 @@ def set_partent(parent, child):
     parent.select_set(False)
 
 
-def construct_mesh(evm: EVM, evmCollection, extract_dir: str, hasHumanBones: bool, texLoader: TextureLoad):
+def construct_mesh(evm: EVM, evmCollection, extract_dir: str, hasHumanBones: bool, texLoader: TextureLoad, merge_material_slots: bool):
     print("Importing mesh")
     vertices = []
     normals = []
@@ -52,6 +52,7 @@ def construct_mesh(evm: EVM, evmCollection, extract_dir: str, hasHumanBones: boo
     uvs3 = []
     weights = []
     boneIndices = []
+    uniqueMaterialIndices: dict = {}
     #bpy.context.scene.collection.children.link(bpy.data.collections.new("looseCoords"))
     for i, vertexGroup in enumerate(evm.meshes):
         faceIndexOffset = len(vertices)
@@ -90,7 +91,17 @@ def construct_mesh(evm: EVM, evmCollection, extract_dir: str, hasHumanBones: boo
                     faces.append((j - 2 + faceIndexOffset, j - 1 + faceIndexOffset, j + faceIndexOffset))
                 else:
                     faces.append((j - 2 + faceIndexOffset, j + faceIndexOffset, j - 1 + faceIndexOffset))
-                materialIndices.append(i)
+                
+                mat_id = MaterialHelper.get_unique_id(vertexGroup.flag, vertexGroup.colorMap, vertexGroup.specularMap, vertexGroup.environmentMap)
+
+                if merge_material_slots:
+                    if mat_id not in uniqueMaterialIndices:
+                        uniqueMaterialIndices[mat_id] = len(uniqueMaterialIndices)
+
+                    materialIndices.append(uniqueMaterialIndices[mat_id])
+                else:
+                    materialIndices.append(i)
+
                 flip = not flip
             else:
                 flip = False
@@ -155,7 +166,7 @@ def construct_mesh(evm: EVM, evmCollection, extract_dir: str, hasHumanBones: boo
                 vgroups[boneName].add([i], weight / 128, "ADD")
             i += 1
     
-    if apply_materials(evm, obj, extract_dir, texLoader):
+    if apply_materials(evm, obj, extract_dir, texLoader, merge_material_slots):
         bm = bmesh.new()
         bm.from_mesh(objmesh)
         uv_layer = bm.loops.layers.uv.new("UVMap1")
@@ -226,16 +237,19 @@ def construct_armature(evm: EVM, evmName: str, hasHumanBones: bool):
     bpy.ops.object.mode_set(mode='OBJECT')
     return ob
 
-def apply_materials(evm: EVM, obj, extract_dir: str, texLoader: TextureLoad):
+def apply_materials(evm: EVM, obj, extract_dir: str, texLoader: TextureLoad, merge_material_slots: bool):
     if evm.header.numMeshes == 0:
         return False
     
     for vGroup in evm.meshes:
-        material = texLoader.makeMaterial(obj.name, vGroup.flag, vGroup.colorMap, vGroup.specularMap, vGroup.environmentMap)
-        obj.data.materials.append(material)
+        material = texLoader.makeMaterial(obj.name, vGroup.flag, vGroup.colorMap, vGroup.specularMap, vGroup.environmentMap, merge_material_slots)
+        
+        if not merge_material_slots or material.name not in obj.data.materials:
+            obj.data.materials.append(material)
+
     return True
 
-def main(evm_file: str, ctxr_path: str = None, overwrite_existing: bool = False):
+def main(evm_file: str, ctxr_path: str = None, overwrite_existing: bool = False, merge_material_slots: bool = False):
     evm = EVM()
     with open(evm_file, "rb") as f:
         evm.fromFile(f)
@@ -265,7 +279,7 @@ def main(evm_file: str, ctxr_path: str = None, overwrite_existing: bool = False)
     
     texLoader = TextureLoad(extract_dir, ctxr_path, overwrite_existing)
     
-    mesh = construct_mesh(evm, col, extract_dir, hasHumanBones, texLoader)
+    mesh = construct_mesh(evm, col, extract_dir, hasHumanBones, texLoader, merge_material_slots)
     amt = construct_armature(evm, collection_name, hasHumanBones)
     set_partent(amt, mesh)
     

--- a/kms/importer/kmsImportOperator.py
+++ b/kms/importer/kmsImportOperator.py
@@ -29,6 +29,7 @@ class ImportMgsKms(bpy.types.Operator, ImportHelper):
     texture_mode: bpy.props.EnumProperty(name="Textures", items=texture_modes, default=0, update=changeTextureMode)
     texture_path: bpy.props.StringProperty(name="Load Path:")
     texture_overwrite: bpy.props.BoolProperty(name="Re-extract existing", default=False)
+    merge_material_slots: bpy.props.BoolProperty(name="Merge Similar Material Slots", default=True)
     
     files: bpy.props.CollectionProperty(
         name="KMS files",
@@ -71,11 +72,11 @@ class ImportMgsKms(bpy.types.Operator, ImportHelper):
             if self.texture_mode == 'ctxr':
                 # Unless you want to unpack every ctxr in advance, this has to be in the kms loader.
                 if os.path.isabs(self.texture_path):
-                    kms_importer.main(kms_path, self.texture_path, self.texture_overwrite)
+                    kms_importer.main(kms_path, self.texture_path, self.texture_overwrite, self.merge_material_slots)
                 else:
-                    kms_importer.main(kms_path, os.path.join(dirname, self.texture_path), self.texture_overwrite)
+                    kms_importer.main(kms_path, os.path.join(dirname, self.texture_path), self.texture_overwrite, self.merge_material_slots)
             else:
-                kms_importer.main(kms_path)
+                kms_importer.main(kms_path, merge_material_slots = self.merge_material_slots)
                 
         return {'FINISHED'}
 
@@ -88,4 +89,6 @@ class ImportMgsKms(bpy.types.Operator, ImportHelper):
             col.prop(self, "texture_path")
         if self.texture_mode == 'ctxr':
             col.prop(self, "texture_overwrite")
+        col.prop(self, "merge_material_slots")
+    
     

--- a/util/materials.py
+++ b/util/materials.py
@@ -2,7 +2,7 @@ import bpy
 import os
 from math import radians
 from ..ctxr.ctxr import CTXR, ctxr_lookup_path
-from .util import replaceExt
+from .util import replaceExt, stripAllExt
 
 class MaterialHelper:
     material: bpy.types.Material
@@ -47,17 +47,23 @@ class MaterialHelper:
         self.links.new(specular_output, env_multiplier.inputs[6])  # 'A'
         self.links.new(env_node.outputs['Color'], env_multiplier.inputs[7])  # 'B'
         return env_multiplier
+    
+    @staticmethod
+    def get_unique_id(flag: int, colorId: int, specularId: int, environmentId: int) -> str:
+        return str(flag)+str(colorId)+str(specularId)+str(specularId)
 
 
 class TextureLoad:
     extract_dir: str
     ctxr_dir: str | None  # ctxr load folder if using ctxr
     ctxr_name_lookup: dict
+    material_cache: dict
     overwrite_existing: bool
 
     def __init__(self, extract_dir: str, ctxr_dir: str = None, overwrite_existing: bool = False):
         self.extract_dir = extract_dir
         self.ctxr_dir = ctxr_dir
+        self.material_cache = {}
         self.ctxr_name_lookup = {}
         self.overwrite_existing = overwrite_existing
 
@@ -110,8 +116,16 @@ class TextureLoad:
             return ""
         return f"{mapID}.tga"
 
-    def makeMaterial(self, name: str, flag: int, colorId: int, specularId: int, environmentId: int) -> bpy.types.Material:
-        material = bpy.data.materials.new(name)
+
+    def makeMaterial(self, name: str, flag: int, colorId: int, specularId: int, environmentId: int, merge_materials: bool) -> bpy.types.Material:
+        unique_id = MaterialHelper.get_unique_id(flag, colorId, specularId, environmentId)
+
+        if merge_materials and unique_id in self.material_cache:
+            return self.material_cache[unique_id]
+
+        colorMapName = self.get_texture_nice_name(colorId)
+        material = bpy.data.materials.new(stripAllExt(colorMapName))
+        self.material_cache[unique_id] = material
         matHelper = MaterialHelper(material)
         # Save flag as custom property
         material["flag"] = flag
@@ -119,6 +133,7 @@ class TextureLoad:
         nodes = matHelper.nodes
         links = matHelper.links
         # Render properties
+        # These two could be exposed as user-defined properties
         material.blend_method = 'HASHED'
         material.use_backface_culling = True
         # PrincipledBSDF and Ouput Shader
@@ -129,7 +144,6 @@ class TextureLoad:
         output_link = links.new( principled.outputs['BSDF'], output.inputs['Surface'] )
 
         colorMap = self.get_texture(colorId)
-        colorMapName = self.get_texture_nice_name(colorId)
         isAlphaBlended = colorMap is not None and colorMapName.find("alp") >= 0 and colorMapName.find("ovl") >= 0
         if colorMap is not None:
             color_image = nodes.new(type='ShaderNodeTexImage')

--- a/util/util.py
+++ b/util/util.py
@@ -108,3 +108,15 @@ def getVertWeight(vert, obj = None, group_name: str = None) -> float:
 
 def replaceExt(path: str, new_ext: str) -> str:
     return f"{os.path.splitext(path)[0]}.{new_ext}"
+
+def stripExt(path: str) -> str:
+    return os.path.splitext(path)[0]
+
+def stripAllExt(path:str) -> str:
+    p, ext = os.path.splitext(path)
+
+    if len(ext) > 0:
+        return stripAllExt(p)
+
+    return p
+    


### PR DESCRIPTION
Merge Material Slots import setting
Instead of creating a new redundant Material and a separate Material Slot for every Vertex Group, 'Merge Similar Material Slots' can be enabled so that importers will keep track of duplicate material settings and collapse them all under a single material and slot when constructing the mesh.

A material is considered to be the same as another when they share the same texture maps and flags.

Additionally, materials are now named after their Base Color Texture name.

Before | After

<img width="300" height="260" alt="material merge before" src="https://github.com/user-attachments/assets/9f568e75-95d9-4a02-b64f-075a93aa2485" />
<img width="300" height="260" alt="material merge after" src="https://github.com/user-attachments/assets/b7ef901c-b040-4a95-b1cd-4324f76e005f" />

I'm certain duplicate material tracking could be made more elegant such that there isn't as much mirrored code on each importer script, but I prefer to leave as little a footprint as possible and let you decide whether to refactor that.

Cheers!